### PR TITLE
meson: Explicit the 'check' argument of run_command()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,4 +35,4 @@ subdir('src')
 subdir('tests')
 
 setup_unittest= find_program('scripts/setupUnitTest.sh')
-run_command(setup_unittest)
+run_command(setup_unittest, check: true)


### PR DESCRIPTION
Fixes the following warning when building on meson 0.61.2:

```
Program scripts/setupUnitTest.sh found: YES (/bin/bash -eu /home/ryonakano/Projects/libvalacore/scripts/setupUnitTest.sh)
WARNING: You should add the boolean check kwarg to the run_command call.
         It currently defaults to false,
         but it will default to true in future releases of meson.
         See also: https://github.com/mesonbuild/meson/issues/9300
```